### PR TITLE
d fixed dead link and upgraded links to https in Legacy Code Section

### DIFF
--- a/legacycode/index.md
+++ b/legacycode/index.md
@@ -5,7 +5,7 @@ title: Legacy Code
 
 Locking down legacy code is one of the major problems when trying to work on existing code. Approval tests facilitates this in a couple of ways.
 
-1. [Producing lots of results](http://blog.approvaltests.org/2010/12/complete-unit-testing.html)
-2. [Verifying large results](http://blog.approvaltests.org/2008/10/approval-tests-pictures-worth-1000...)
+1. [Producing lots of results](https://blog.approvaltests.org/2010/12/complete-unit-testing.html)
+2. [Verifying large results](https://blog.approvaltests.org/2008/10/approval-tests-pictures-worth-1000.html)
 
 Here is a video of me locking down the code from LegacyCodeRetreat.


### PR DESCRIPTION
## Description

In [Legacy Code section](https://approvaltests.com/legacycode/).
- Link to "Verifying large results" was broken.
- Both links to `blog.approvaltests.org` were `http://`

## The solution

- Link to correct url for "Verifying large results"
- Use `https://` for `blog.approvaltests.org` links